### PR TITLE
[Mod] Modify directory path method for config file

### DIFF
--- a/TodotxtManager/TaskListManager.cs
+++ b/TodotxtManager/TaskListManager.cs
@@ -8,8 +8,7 @@ using TaskList = System.Collections.Generic.List<TodotxtManager.TaskContainer>;
 
 namespace TodotxtManager {
     public class TaskListManager {
-        private string filePath = Directory.GetParent(Assembly.GetExecutingAssembly().Location)
-                                    + "/todolist.xml";
+        private string filePath = $"{Environment.CurrentDirectory}/todolist.xml";
         private TaskList taskList = new TaskList();
 
         /// <summary>


### PR DESCRIPTION
This is temporary modification. Executing assembly info indicates under from tmp directory because of specification of PublishSingleFile.
In this version, save file will not be in same directory if the program is executed from shortcuts.